### PR TITLE
Fix an error in the docker recipe

### DIFF
--- a/docker/.dockerignore
+++ b/docker/.dockerignore
@@ -1,2 +1,1 @@
 **
-!ledger/local/**

--- a/docker/abci/Dockerfile
+++ b/docker/abci/Dockerfile
@@ -1,12 +1,9 @@
 FROM many_local/repo_build:latest as builder
 
 # ==== STAGE 2 ====
-FROM debian:bullseye as runtime
+FROM debian:stable as runtime
 
 RUN useradd -ms /bin/bash many
-RUN apt-get update && \
-    apt-get -y upgrade && \
-    apt-get -y install openssl curl netcat iputils-ping
 
 STOPSIGNAL SIGTERM
 

--- a/docker/ledger/Dockerfile
+++ b/docker/ledger/Dockerfile
@@ -4,9 +4,6 @@ FROM many_local/repo_build:latest as builder
 FROM debian:bullseye as runtime
 
 RUN useradd -ms /bin/bash many
-RUN apt-get update && \
-    apt-get -y upgrade && \
-    apt-get -y install openssl
 
 # Contains the ledger.db store.
 VOLUME /persistent


### PR DESCRIPTION
It seems like we cannot do apt-get update, but good thing is
we dont need those tools installed in our docker images anyway.