### PR TITLE
cargo update & ssh:// → https://

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -250,9 +250,9 @@ checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
 name = "base64ct"
-version = "1.3.3"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "874f8444adcb4952a8bc51305c8be95c8ec8237bb0d2e78d2e039f771f8828a0"
+checksum = "71acf5509fc522cce1b100ac0121c635129bfd4d91cdf036bcc9b9935f97ccf5"
 
 [[package]]
 name = "bindgen"
@@ -326,9 +326,9 @@ checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
 
 [[package]]
 name = "blocking"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "046e47d4b2d391b1f6f8b407b1deb8dee56c1852ccd868becf2710f601b5f427"
+checksum = "c6ccb65d468978a086b69884437ded69a90faab3bbe6e67f242173ea728acccc"
 dependencies = [
  "async-channel",
  "async-task",
@@ -412,7 +412,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
 dependencies = [
- "nom 7.1.0",
+ "nom 7.1.1",
 ]
 
 [[package]]
@@ -611,9 +611,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.2"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e54ea8bc3fb1ee042f5aace6e3c6e025d3874866da222930f70ce62aceba0bfa"
+checksum = "5aaa7bd5fb665c6864b5f963dd9097905c54125909c7aa94c9e18507cdbe6c53"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -632,10 +632,11 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.7"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c00d6d2ea26e8b151d99093005cb442fb9a37aeaca582a03ec70946f49ab5ed9"
+checksum = "1145cf131a2c6ba0615079ab6a638f7e1973ac9c2634fcbeaaad6114246efe8c"
 dependencies = [
+ "autocfg",
  "cfg-if",
  "crossbeam-utils",
  "lazy_static",
@@ -645,9 +646,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.7"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e5bed1f1c269533fa816a0a5492b3545209a205ca1a54842be180eb63a16a6"
+checksum = "0bf124c720b7686e3c2663cf54062ab0f68a88af2fb6a030e87e30bf721fcb38"
 dependencies = [
  "cfg-if",
  "lazy_static",
@@ -1235,9 +1236,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.11"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9f1f717ddc7b2ba36df7e871fd88db79326551d3d6f1fc406fbfd28b582ff8e"
+checksum = "62eeb471aa3e3c9197aa4bfeabfe02982f6dc96f750486c0bb0009ac58b26d2b"
 dependencies = [
  "bytes",
  "fnv",
@@ -1618,9 +1619,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.119"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bf2e165bb3457c8e098ea76f3e3bc9db55f87aa90d52d0e6be741470916aaa4"
+checksum = "ad5c14e80759d0939d013e6ca49930e59fc53dd8e5009132f76240c179380c09"
 
 [[package]]
 name = "libloading"
@@ -1665,7 +1666,7 @@ dependencies = [
 [[package]]
 name = "many"
 version = "0.1.0"
-source = "git+ssh://git@github.com/l-1-labs/many-rs.git?rev=bc3d0ee671c49eef95f9b068fb3a98a262dc62b5#bc3d0ee671c49eef95f9b068fb3a98a262dc62b5"
+source = "git+https://github.com/l-1-labs/many-rs.git?rev=feb5837edbe8c8d8b9323b4b081b69cc88f782bb#feb5837edbe8c8d8b9323b4b081b69cc88f782bb"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1735,7 +1736,7 @@ dependencies = [
 [[package]]
 name = "many-client"
 version = "0.1.0"
-source = "git+ssh://git@github.com/l-1-labs/many-rs.git?rev=bc3d0ee671c49eef95f9b068fb3a98a262dc62b5#bc3d0ee671c49eef95f9b068fb3a98a262dc62b5"
+source = "git+https://github.com/l-1-labs/many-rs.git?rev=feb5837edbe8c8d8b9323b4b081b69cc88f782bb#feb5837edbe8c8d8b9323b4b081b69cc88f782bb"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1844,7 +1845,7 @@ dependencies = [
 [[package]]
 name = "many-macros"
 version = "0.1.0"
-source = "git+ssh://git@github.com/l-1-labs/many-rs.git?rev=bc3d0ee671c49eef95f9b068fb3a98a262dc62b5#bc3d0ee671c49eef95f9b068fb3a98a262dc62b5"
+source = "git+https://github.com/l-1-labs/many-rs.git?rev=feb5837edbe8c8d8b9323b4b081b69cc88f782bb#feb5837edbe8c8d8b9323b4b081b69cc88f782bb"
 dependencies = [
  "inflections",
  "proc-macro2",
@@ -1925,7 +1926,7 @@ dependencies = [
 [[package]]
 name = "minicose"
 version = "0.1.0"
-source = "git+ssh://git@github.com/l-1-labs/rust-minicose.git#3b8cd133fe028bc78f26eae30ea87e23f2f9e91b"
+source = "git+https://github.com/l-1-labs/rust-minicose.git#3b8cd133fe028bc78f26eae30ea87e23f2f9e91b"
 dependencies = [
  "ciborium 0.2.0 (git+https://github.com/hansl/ciborium?rev=230e84cf939cfef9d00958f104cafe72774ffc86)",
  "ciborium-ll 0.2.0 (git+https://github.com/hansl/ciborium?rev=230e84cf939cfef9d00958f104cafe72774ffc86)",
@@ -1954,14 +1955,15 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba272f85fa0b41fc91872be579b3bbe0f56b792aa361a380eb669469f68dafb2"
+checksum = "52da4364ffb0e4fe33a9841a98a3f3014fb964045ce4f7a45a398243c8d6b0c9"
 dependencies = [
  "libc",
  "log",
  "miow",
  "ntapi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "winapi",
 ]
 
@@ -2020,13 +2022,12 @@ dependencies = [
 
 [[package]]
 name = "nom"
-version = "7.1.0"
+version = "7.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b1d11e1ef389c76fe5b81bcaf2ea32cf88b62bc494e19f493d0b30e7a930109"
+checksum = "a8903e5a29a317527874d0402f867152a3d21c908bb0b933e416c65e301d4c36"
 dependencies = [
  "memchr",
  "minimal-lexical",
- "version_check",
 ]
 
 [[package]]
@@ -2114,9 +2115,9 @@ dependencies = [
 
 [[package]]
 name = "num_threads"
-version = "0.1.3"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97ba99ba6393e2c3734791401b66902d981cb03bf190af674ca69949b6d5fb15"
+checksum = "aba1801fb138d8e85e11d0fc70baf4fe1cdfffda7c6cd34a854905df588e5ed0"
 dependencies = [
  "libc",
 ]
@@ -2512,9 +2513,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.15"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "864d3e96a899863136fc6e99f3d7cae289dafe43bf2c5ac19b70df7210c0a145"
+checksum = "b4af2ec4714533fcdf07e886f17025ace8b997b9ce51204ee69b6da831c3da57"
 dependencies = [
  "proc-macro2",
 ]
@@ -2671,9 +2672,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.9"
+version = "0.11.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87f242f1488a539a79bac6dbe7c8609ae43b7914b7736210f239a37cccb32525"
+checksum = "46a1f7aa4f35e5e8b4160449f51afc758f0ce6454315a9fa7d0d113e958c41eb"
 dependencies = [
  "base64 0.13.0",
  "bytes",
@@ -3186,9 +3187,9 @@ checksum = "734676eb262c623cec13c3155096e08d1f8f29adce39ba17948b18dad1e54142"
 
 [[package]]
 name = "syn"
-version = "1.0.86"
+version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a65b3f4ffa0092e9887669db0eae07941f023991ab58ea44da8fe8e2d511c6b"
+checksum = "ea297be220d52398dcc07ce15a209fce436d361735ac1db700cab3b6cdfb9f54"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3249,7 +3250,7 @@ dependencies = [
 [[package]]
 name = "tendermint"
 version = "0.24.0-pre.1"
-source = "git+https://github.com/informalsystems/tendermint-rs.git#3ba454051a3a2dbd360c95ca1276c2542adae84d"
+source = "git+https://github.com/informalsystems/tendermint-rs.git#84012a78fc4712a950ca7b732f47d5aff112e31a"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3277,7 +3278,7 @@ dependencies = [
 [[package]]
 name = "tendermint-abci"
 version = "0.24.0-pre.1"
-source = "git+https://github.com/informalsystems/tendermint-rs.git#3ba454051a3a2dbd360c95ca1276c2542adae84d"
+source = "git+https://github.com/informalsystems/tendermint-rs.git#84012a78fc4712a950ca7b732f47d5aff112e31a"
 dependencies = [
  "bytes",
  "flex-error",
@@ -3289,7 +3290,7 @@ dependencies = [
 [[package]]
 name = "tendermint-config"
 version = "0.24.0-pre.1"
-source = "git+https://github.com/informalsystems/tendermint-rs.git#3ba454051a3a2dbd360c95ca1276c2542adae84d"
+source = "git+https://github.com/informalsystems/tendermint-rs.git#84012a78fc4712a950ca7b732f47d5aff112e31a"
 dependencies = [
  "flex-error",
  "serde",
@@ -3302,7 +3303,7 @@ dependencies = [
 [[package]]
 name = "tendermint-proto"
 version = "0.24.0-pre.1"
-source = "git+https://github.com/informalsystems/tendermint-rs.git#3ba454051a3a2dbd360c95ca1276c2542adae84d"
+source = "git+https://github.com/informalsystems/tendermint-rs.git#84012a78fc4712a950ca7b732f47d5aff112e31a"
 dependencies = [
  "bytes",
  "flex-error",
@@ -3319,7 +3320,7 @@ dependencies = [
 [[package]]
 name = "tendermint-rpc"
 version = "0.24.0-pre.1"
-source = "git+https://github.com/informalsystems/tendermint-rs.git#3ba454051a3a2dbd360c95ca1276c2542adae84d"
+source = "git+https://github.com/informalsystems/tendermint-rs.git#84012a78fc4712a950ca7b732f47d5aff112e31a"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3746,6 +3747,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
 name = "wasm-bindgen"
 version = "0.2.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3925,9 +3932,9 @@ checksum = "504a2476202769977a040c6364301a3f65d0cc9e3fb08600b2bda150a0488316"
 
 [[package]]
 name = "winreg"
-version = "0.7.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0120db82e8a1e0b9fb3345a539c478767c0048d842860994d96113d5b667bd69"
+checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
 dependencies = [
  "winapi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 #[patch."https://github.com/l-1-labs/rust-minicose"]
 #minicose = { path = "../rust-minicose" }
 
-#[patch."ssh://git@github.com/l-1-labs/many-rs.git"]
+#[patch."https://github.com/l-1-labs/many-rs.git"]
 #many = { path = "../many-rs/src/many" }
 #many-cli = { path = "../many-rs/src/many-cli" }
 #many-client = { path = "../many-rs/src/many-client" }

--- a/src/http_proxy/Cargo.toml
+++ b/src/http_proxy/Cargo.toml
@@ -11,8 +11,8 @@ doc = false
 clap = { version = "3.0.0", features = ["derive"] }
 hex = "0.4.3"
 minicbor = { version = "0.12.0", features = ["derive", "std"] }
-many = { git = "https://github.com/l-1-labs/many-rs.git", rev = "ea842bb5c67a76bec284c4addbda38147c57cbc6" }
-many-client = { git = "https://github.com/l-1-labs/many-rs.git", rev = "ea842bb5c67a76bec284c4addbda38147c57cbc6" }
+many = { git = "https://github.com/l-1-labs/many-rs.git", rev = "feb5837edbe8c8d8b9323b4b081b69cc88f782bb" }
+many-client = { git = "https://github.com/l-1-labs/many-rs.git", rev = "feb5837edbe8c8d8b9323b4b081b69cc88f782bb" }
 many-kvstore = { path = "../many-kvstore" }
 new_mime_guess = "4.0.0"
 tiny_http = "0.9.0"

--- a/src/http_proxy/Cargo.toml
+++ b/src/http_proxy/Cargo.toml
@@ -11,8 +11,8 @@ doc = false
 clap = { version = "3.0.0", features = ["derive"] }
 hex = "0.4.3"
 minicbor = { version = "0.12.0", features = ["derive", "std"] }
-many = { git = "ssh://git@github.com/l-1-labs/many-rs.git", rev = "bc3d0ee671c49eef95f9b068fb3a98a262dc62b5" }
-many-client = { git = "ssh://git@github.com/l-1-labs/many-rs.git", rev = "bc3d0ee671c49eef95f9b068fb3a98a262dc62b5" }
+many = { git = "https://github.com/l-1-labs/many-rs.git", rev = "ea842bb5c67a76bec284c4addbda38147c57cbc6" }
+many-client = { git = "https://github.com/l-1-labs/many-rs.git", rev = "ea842bb5c67a76bec284c4addbda38147c57cbc6" }
 many-kvstore = { path = "../many-kvstore" }
 new_mime_guess = "4.0.0"
 tiny_http = "0.9.0"

--- a/src/kvstore/Cargo.toml
+++ b/src/kvstore/Cargo.toml
@@ -11,8 +11,8 @@ doc = false
 clap = { version = "3.0.0", features = ["derive"] }
 hex = "0.4.3"
 minicbor = { version = "0.12.0", features = ["derive", "std"] }
-many = { git = "https://github.com/l-1-labs/many-rs.git", rev = "ea842bb5c67a76bec284c4addbda38147c57cbc6" }
-many-client = { git = "https://github.com/l-1-labs/many-rs.git", rev = "ea842bb5c67a76bec284c4addbda38147c57cbc6" }
+many = { git = "https://github.com/l-1-labs/many-rs.git", rev = "feb5837edbe8c8d8b9323b4b081b69cc88f782bb" }
+many-client = { git = "https://github.com/l-1-labs/many-rs.git", rev = "feb5837edbe8c8d8b9323b4b081b69cc88f782bb" }
 many-kvstore = { path = "../many-kvstore" }
 tracing = "0.1.29"
 tracing-subscriber = "0.3.3"

--- a/src/kvstore/Cargo.toml
+++ b/src/kvstore/Cargo.toml
@@ -11,8 +11,8 @@ doc = false
 clap = { version = "3.0.0", features = ["derive"] }
 hex = "0.4.3"
 minicbor = { version = "0.12.0", features = ["derive", "std"] }
-many = { git = "ssh://git@github.com/l-1-labs/many-rs.git", rev = "bc3d0ee671c49eef95f9b068fb3a98a262dc62b5" }
-many-client = { git = "ssh://git@github.com/l-1-labs/many-rs.git", rev = "bc3d0ee671c49eef95f9b068fb3a98a262dc62b5" }
+many = { git = "https://github.com/l-1-labs/many-rs.git", rev = "ea842bb5c67a76bec284c4addbda38147c57cbc6" }
+many-client = { git = "https://github.com/l-1-labs/many-rs.git", rev = "ea842bb5c67a76bec284c4addbda38147c57cbc6" }
 many-kvstore = { path = "../many-kvstore" }
 tracing = "0.1.29"
 tracing-subscriber = "0.3.3"

--- a/src/ledger/Cargo.toml
+++ b/src/ledger/Cargo.toml
@@ -16,8 +16,8 @@ hex = "0.4.3"
 lazy_static = "1.4.0"
 minicbor = { version = "0.12.0", features = ["derive", "std"] }
 num-bigint = "0.4.3"
-many = { git = "ssh://git@github.com/l-1-labs/many-rs.git", rev = "bc3d0ee671c49eef95f9b068fb3a98a262dc62b5" }
-many-client = { git = "ssh://git@github.com/l-1-labs/many-rs.git", rev = "bc3d0ee671c49eef95f9b068fb3a98a262dc62b5" }
+many = { git = "https://github.com/l-1-labs/many-rs.git", rev = "ea842bb5c67a76bec284c4addbda38147c57cbc6" }
+many-client = { git = "https://github.com/l-1-labs/many-rs.git", rev = "ea842bb5c67a76bec284c4addbda38147c57cbc6" }
 regex = "1.5.4"
 ring = "0.17.0-alpha.10"
 tracing = "0.1.29"

--- a/src/ledger/Cargo.toml
+++ b/src/ledger/Cargo.toml
@@ -16,8 +16,8 @@ hex = "0.4.3"
 lazy_static = "1.4.0"
 minicbor = { version = "0.12.0", features = ["derive", "std"] }
 num-bigint = "0.4.3"
-many = { git = "https://github.com/l-1-labs/many-rs.git", rev = "ea842bb5c67a76bec284c4addbda38147c57cbc6" }
-many-client = { git = "https://github.com/l-1-labs/many-rs.git", rev = "ea842bb5c67a76bec284c4addbda38147c57cbc6" }
+many = { git = "https://github.com/l-1-labs/many-rs.git", rev = "feb5837edbe8c8d8b9323b4b081b69cc88f782bb" }
+many-client = { git = "https://github.com/l-1-labs/many-rs.git", rev = "feb5837edbe8c8d8b9323b4b081b69cc88f782bb" }
 regex = "1.5.4"
 ring = "0.17.0-alpha.10"
 tracing = "0.1.29"

--- a/src/many-abci/Cargo.toml
+++ b/src/many-abci/Cargo.toml
@@ -15,8 +15,8 @@ hex = "0.4.3"
 lazy_static = "1.4.0"
 minicbor = { version = "0.12.0", features = ["derive", "std"] }
 minicose = { git = "https://github.com/l-1-labs/rust-minicose.git" }
-many = { git = "https://github.com/l-1-labs/many-rs.git", rev = "ea842bb5c67a76bec284c4addbda38147c57cbc6" }
-many-client = { git = "https://github.com/l-1-labs/many-rs.git", rev = "ea842bb5c67a76bec284c4addbda38147c57cbc6" }
+many = { git = "https://github.com/l-1-labs/many-rs.git", rev = "feb5837edbe8c8d8b9323b4b081b69cc88f782bb" }
+many-client = { git = "https://github.com/l-1-labs/many-rs.git", rev = "feb5837edbe8c8d8b9323b4b081b69cc88f782bb" }
 reqwest = "0.11.6"
 sha2 = "0.10.1"
 smol = "1.2.5"

--- a/src/many-abci/Cargo.toml
+++ b/src/many-abci/Cargo.toml
@@ -14,9 +14,9 @@ clap = { version = "3.0.0", features = ["derive"] }
 hex = "0.4.3"
 lazy_static = "1.4.0"
 minicbor = { version = "0.12.0", features = ["derive", "std"] }
-minicose = { git = "ssh://git@github.com/l-1-labs/rust-minicose.git" }
-many = { git = "ssh://git@github.com/l-1-labs/many-rs.git", rev = "bc3d0ee671c49eef95f9b068fb3a98a262dc62b5" }
-many-client = { git = "ssh://git@github.com/l-1-labs/many-rs.git", rev = "bc3d0ee671c49eef95f9b068fb3a98a262dc62b5" }
+minicose = { git = "https://github.com/l-1-labs/rust-minicose.git" }
+many = { git = "https://github.com/l-1-labs/many-rs.git", rev = "ea842bb5c67a76bec284c4addbda38147c57cbc6" }
+many-client = { git = "https://github.com/l-1-labs/many-rs.git", rev = "ea842bb5c67a76bec284c4addbda38147c57cbc6" }
 reqwest = "0.11.6"
 sha2 = "0.10.1"
 smol = "1.2.5"

--- a/src/many-hwinfo/Cargo.toml
+++ b/src/many-hwinfo/Cargo.toml
@@ -12,7 +12,7 @@ async-trait = "0.1.51"
 clap = { version = "3.0.0", features = ["derive"] }
 hex = "0.4.3"
 minicbor = { version = "0.12.0", features = ["derive", "std"] }
-many = { git = "ssh://git@github.com/l-1-labs/many-rs.git", rev = "bc3d0ee671c49eef95f9b068fb3a98a262dc62b5", features = ["pem"] }
+many = { git = "https://github.com/l-1-labs/many-rs.git", rev = "ea842bb5c67a76bec284c4addbda38147c57cbc6", features = ["pem"] }
 sysinfo = "0.23.1"
 sys-info = "0.9.1"
 tracing = "0.1.28"

--- a/src/many-hwinfo/Cargo.toml
+++ b/src/many-hwinfo/Cargo.toml
@@ -12,7 +12,7 @@ async-trait = "0.1.51"
 clap = { version = "3.0.0", features = ["derive"] }
 hex = "0.4.3"
 minicbor = { version = "0.12.0", features = ["derive", "std"] }
-many = { git = "https://github.com/l-1-labs/many-rs.git", rev = "ea842bb5c67a76bec284c4addbda38147c57cbc6", features = ["pem"] }
+many = { git = "https://github.com/l-1-labs/many-rs.git", rev = "feb5837edbe8c8d8b9323b4b081b69cc88f782bb", features = ["pem"] }
 sysinfo = "0.23.1"
 sys-info = "0.9.1"
 tracing = "0.1.28"

--- a/src/many-kvstore/Cargo.toml
+++ b/src/many-kvstore/Cargo.toml
@@ -16,7 +16,7 @@ itertools = "0.10.3"
 lazy_static = "1.4.0"
 num-bigint = "0.4.3"
 minicbor = { version = "0.12.0", features = ["derive", "std"] }
-many = { git = "ssh://git@github.com/l-1-labs/many-rs.git", rev = "bc3d0ee671c49eef95f9b068fb3a98a262dc62b5", features = ["pem"] }
+many = { git = "https://github.com/l-1-labs/many-rs.git", rev = "ea842bb5c67a76bec284c4addbda38147c57cbc6", features = ["pem"] }
 many-abci = { path = "../many-abci" }
 serde = "1.0.130"
 serde_json = "1.0.72"

--- a/src/many-kvstore/Cargo.toml
+++ b/src/many-kvstore/Cargo.toml
@@ -16,7 +16,7 @@ itertools = "0.10.3"
 lazy_static = "1.4.0"
 num-bigint = "0.4.3"
 minicbor = { version = "0.12.0", features = ["derive", "std"] }
-many = { git = "https://github.com/l-1-labs/many-rs.git", rev = "ea842bb5c67a76bec284c4addbda38147c57cbc6", features = ["pem"] }
+many = { git = "https://github.com/l-1-labs/many-rs.git", rev = "feb5837edbe8c8d8b9323b4b081b69cc88f782bb", features = ["pem"] }
 many-abci = { path = "../many-abci" }
 serde = "1.0.130"
 serde_json = "1.0.72"

--- a/src/many-ledger/Cargo.toml
+++ b/src/many-ledger/Cargo.toml
@@ -18,7 +18,7 @@ lazy_static = "1.4.0"
 num-bigint = "0.4.3"
 num-traits = "0.2.14"
 minicbor = { version = "0.12.0", features = ["derive", "std"] }
-many = { git = "https://github.com/l-1-labs/many-rs.git", rev = "ea842bb5c67a76bec284c4addbda38147c57cbc6", features = ["pem"] }
+many = { git = "https://github.com/l-1-labs/many-rs.git", rev = "feb5837edbe8c8d8b9323b4b081b69cc88f782bb", features = ["pem"] }
 many-abci = { path = "../many-abci" }
 many-kvstore = { path = "../many-kvstore" }
 serde = "1.0.130"
@@ -30,7 +30,7 @@ tracing-subscriber = "0.2.24"
 typenum = "1.15.0"
 
 [dev-dependencies]
-many = { git = "https://github.com/l-1-labs/many-rs.git", rev = "ea842bb5c67a76bec284c4addbda38147c57cbc6" }
-many-client = { git = "https://github.com/l-1-labs/many-rs.git", rev = "ea842bb5c67a76bec284c4addbda38147c57cbc6" }
+many = { git = "https://github.com/l-1-labs/many-rs.git", rev = "feb5837edbe8c8d8b9323b4b081b69cc88f782bb" }
+many-client = { git = "https://github.com/l-1-labs/many-rs.git", rev = "feb5837edbe8c8d8b9323b4b081b69cc88f782bb" }
 tempfile = "3.3.0"
 

--- a/src/many-ledger/Cargo.toml
+++ b/src/many-ledger/Cargo.toml
@@ -18,7 +18,7 @@ lazy_static = "1.4.0"
 num-bigint = "0.4.3"
 num-traits = "0.2.14"
 minicbor = { version = "0.12.0", features = ["derive", "std"] }
-many = { git = "ssh://git@github.com/l-1-labs/many-rs.git", rev = "bc3d0ee671c49eef95f9b068fb3a98a262dc62b5", features = ["pem"] }
+many = { git = "https://github.com/l-1-labs/many-rs.git", rev = "ea842bb5c67a76bec284c4addbda38147c57cbc6", features = ["pem"] }
 many-abci = { path = "../many-abci" }
 many-kvstore = { path = "../many-kvstore" }
 serde = "1.0.130"
@@ -30,7 +30,7 @@ tracing-subscriber = "0.2.24"
 typenum = "1.15.0"
 
 [dev-dependencies]
-many = { git = "ssh://git@github.com/l-1-labs/many-rs.git", rev = "bc3d0ee671c49eef95f9b068fb3a98a262dc62b5", features = ["pem", "raw"] }
-many-client = { git = "ssh://git@github.com/l-1-labs/many-rs.git", rev = "bc3d0ee671c49eef95f9b068fb3a98a262dc62b5" }
+many = { git = "https://github.com/l-1-labs/many-rs.git", rev = "ea842bb5c67a76bec284c4addbda38147c57cbc6" }
+many-client = { git = "https://github.com/l-1-labs/many-rs.git", rev = "ea842bb5c67a76bec284c4addbda38147c57cbc6" }
 tempfile = "3.3.0"
 

--- a/src/many-ledger/Cargo.toml
+++ b/src/many-ledger/Cargo.toml
@@ -18,7 +18,7 @@ lazy_static = "1.4.0"
 num-bigint = "0.4.3"
 num-traits = "0.2.14"
 minicbor = { version = "0.12.0", features = ["derive", "std"] }
-many = { git = "https://github.com/l-1-labs/many-rs.git", rev = "feb5837edbe8c8d8b9323b4b081b69cc88f782bb", features = ["pem"] }
+many = { git = "https://github.com/l-1-labs/many-rs.git", rev = "feb5837edbe8c8d8b9323b4b081b69cc88f782bb", features = ["pem", "raw"] }
 many-abci = { path = "../many-abci" }
 many-kvstore = { path = "../many-kvstore" }
 serde = "1.0.130"


### PR DESCRIPTION
Use https:// git url instead of ssh:// now that the repositories are
public