### PR TITLE
Add HSM support to `ledger`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,6 +78,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbf56136a5198c7b01a49e3afcbef6cf84597273d298f54432926024107b0109"
 
 [[package]]
+name = "asn1"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfffb35195feaeffb071af0f7a643405667813dd8629c27cb0c310fb76654ab1"
+dependencies = [
+ "chrono",
+]
+
+[[package]]
 name = "async-channel"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -687,6 +696,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "cryptoki"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "503aa2bd88796da9bc6baf2c47696da40f135721b3d6680c7c6cee0b7d1f7a59"
+dependencies = [
+ "cryptoki-sys",
+ "derivative",
+ "libloading",
+ "log",
+]
+
+[[package]]
+name = "cryptoki-sys"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aec220169d3b1705b54bce57e459873828e5c3bf0e25b96e5f2142acbbb71dda"
+dependencies = [
+ "libloading",
+ "target-lexicon",
+]
+
+[[package]]
 name = "ct-logs"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -785,6 +816,17 @@ checksum = "6919815d73839e7ad218de758883aae3a257ba6759ce7a9992501efbb53d705c"
 dependencies = [
  "const-oid 0.7.1",
  "pem-rfc7468 0.3.1",
+]
+
+[[package]]
+name = "derivative"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1358,8 +1400,8 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "hex",
- "many",
- "many-client",
+ "many 0.1.0 (git+https://github.com/l-1-labs/many-rs.git?rev=4b642446c83cc5d541773fdd2c343733c803900b)",
+ "many-client 0.1.0 (git+https://github.com/l-1-labs/many-rs.git?rev=4b642446c83cc5d541773fdd2c343733c803900b)",
  "many-kvstore",
  "minicbor",
  "new_mime_guess",
@@ -1575,8 +1617,8 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "hex",
- "many",
- "many-client",
+ "many 0.1.0 (git+https://github.com/l-1-labs/many-rs.git?rev=4b642446c83cc5d541773fdd2c343733c803900b)",
+ "many-client 0.1.0 (git+https://github.com/l-1-labs/many-rs.git?rev=4b642446c83cc5d541773fdd2c343733c803900b)",
  "many-kvstore",
  "minicbor",
  "tokio",
@@ -1606,12 +1648,13 @@ dependencies = [
  "fmerk",
  "hex",
  "lazy_static",
- "many",
- "many-client",
+ "many 0.1.0 (git+https://github.com/l-1-labs/many-rs.git?rev=26b4d29209907ad8986905fcfa33535ed1ba4f72)",
+ "many-client 0.1.0 (git+https://github.com/l-1-labs/many-rs.git?rev=26b4d29209907ad8986905fcfa33535ed1ba4f72)",
  "minicbor",
  "num-bigint 0.4.3",
  "regex",
  "ring 0.17.0-alpha.11",
+ "rpassword",
  "tokio",
  "tracing",
  "tracing-subscriber 0.3.9",
@@ -1666,6 +1709,54 @@ dependencies = [
 [[package]]
 name = "many"
 version = "0.1.0"
+source = "git+https://github.com/l-1-labs/many-rs.git?rev=26b4d29209907ad8986905fcfa33535ed1ba4f72#26b4d29209907ad8986905fcfa33535ed1ba4f72"
+dependencies = [
+ "anyhow",
+ "asn1",
+ "async-trait",
+ "backtrace",
+ "base32",
+ "base64 0.13.0",
+ "cbor-diag",
+ "crc-any",
+ "cryptoki",
+ "derive_builder",
+ "ecdsa",
+ "ed25519",
+ "ed25519-dalek",
+ "fixed",
+ "hex",
+ "lazy_static",
+ "many-macros 0.1.0 (git+https://github.com/l-1-labs/many-rs.git?rev=26b4d29209907ad8986905fcfa33535ed1ba4f72)",
+ "minicbor",
+ "minicose",
+ "num-bigint 0.4.3",
+ "num-derive",
+ "num-traits",
+ "once_cell",
+ "openssh-keys",
+ "p256",
+ "pkcs8 0.8.0",
+ "rand 0.8.5",
+ "regex",
+ "reqwest",
+ "ring 0.16.20",
+ "ring-compat",
+ "serde",
+ "sha2 0.10.2",
+ "sha3",
+ "signature",
+ "simple_asn1 0.5.4",
+ "static_assertions",
+ "thiserror",
+ "tiny_http",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "many"
+version = "0.1.0"
 source = "git+https://github.com/l-1-labs/many-rs.git?rev=4b642446c83cc5d541773fdd2c343733c803900b#4b642446c83cc5d541773fdd2c343733c803900b"
 dependencies = [
  "anyhow",
@@ -1682,7 +1773,7 @@ dependencies = [
  "fixed",
  "hex",
  "lazy_static",
- "many-macros",
+ "many-macros 0.1.0 (git+https://github.com/l-1-labs/many-rs.git?rev=4b642446c83cc5d541773fdd2c343733c803900b)",
  "minicbor",
  "minicose",
  "num-bigint 0.4.3",
@@ -1717,8 +1808,8 @@ dependencies = [
  "clap",
  "hex",
  "lazy_static",
- "many",
- "many-client",
+ "many 0.1.0 (git+https://github.com/l-1-labs/many-rs.git?rev=4b642446c83cc5d541773fdd2c343733c803900b)",
+ "many-client 0.1.0 (git+https://github.com/l-1-labs/many-rs.git?rev=4b642446c83cc5d541773fdd2c343733c803900b)",
  "minicbor",
  "minicose",
  "reqwest",
@@ -1731,6 +1822,50 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber 0.2.25",
+]
+
+[[package]]
+name = "many-client"
+version = "0.1.0"
+source = "git+https://github.com/l-1-labs/many-rs.git?rev=26b4d29209907ad8986905fcfa33535ed1ba4f72#26b4d29209907ad8986905fcfa33535ed1ba4f72"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "backtrace",
+ "base32",
+ "base64 0.13.0",
+ "cbor-diag",
+ "crc-any",
+ "derive_builder",
+ "ecdsa",
+ "ed25519",
+ "ed25519-dalek",
+ "fixed",
+ "hex",
+ "lazy_static",
+ "many 0.1.0 (git+https://github.com/l-1-labs/many-rs.git?rev=26b4d29209907ad8986905fcfa33535ed1ba4f72)",
+ "minicbor",
+ "minicose",
+ "num-bigint 0.4.3",
+ "num-derive",
+ "num-traits",
+ "openssh-keys",
+ "p256",
+ "pkcs8 0.8.0",
+ "rand 0.8.5",
+ "regex",
+ "reqwest",
+ "ring 0.16.20",
+ "ring-compat",
+ "serde",
+ "sha3",
+ "signature",
+ "simple_asn1 0.5.4",
+ "static_assertions",
+ "thiserror",
+ "tiny_http",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -1752,7 +1887,7 @@ dependencies = [
  "fixed",
  "hex",
  "lazy_static",
- "many",
+ "many 0.1.0 (git+https://github.com/l-1-labs/many-rs.git?rev=4b642446c83cc5d541773fdd2c343733c803900b)",
  "minicbor",
  "minicose",
  "num-bigint 0.4.3",
@@ -1784,7 +1919,7 @@ dependencies = [
  "async-trait",
  "clap",
  "hex",
- "many",
+ "many 0.1.0 (git+https://github.com/l-1-labs/many-rs.git?rev=4b642446c83cc5d541773fdd2c343733c803900b)",
  "minicbor",
  "sys-info",
  "sysinfo",
@@ -1802,7 +1937,7 @@ dependencies = [
  "hex",
  "itertools",
  "lazy_static",
- "many",
+ "many 0.1.0 (git+https://github.com/l-1-labs/many-rs.git?rev=4b642446c83cc5d541773fdd2c343733c803900b)",
  "many-abci",
  "minicbor",
  "num-bigint 0.4.3",
@@ -1825,9 +1960,9 @@ dependencies = [
  "hex",
  "itertools",
  "lazy_static",
- "many",
+ "many 0.1.0 (git+https://github.com/l-1-labs/many-rs.git?rev=4b642446c83cc5d541773fdd2c343733c803900b)",
  "many-abci",
- "many-client",
+ "many-client 0.1.0 (git+https://github.com/l-1-labs/many-rs.git?rev=4b642446c83cc5d541773fdd2c343733c803900b)",
  "many-kvstore",
  "minicbor",
  "num-bigint 0.4.3",
@@ -1840,6 +1975,19 @@ dependencies = [
  "tracing",
  "tracing-subscriber 0.2.25",
  "typenum",
+]
+
+[[package]]
+name = "many-macros"
+version = "0.1.0"
+source = "git+https://github.com/l-1-labs/many-rs.git?rev=26b4d29209907ad8986905fcfa33535ed1ba4f72#26b4d29209907ad8986905fcfa33535ed1ba4f72"
+dependencies = [
+ "inflections",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_tokenstream",
+ "syn",
 ]
 
 [[package]]
@@ -2765,6 +2913,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rpassword"
+version = "6.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bf099a1888612545b683d2661a1940089f6c2e5a8e38979b2159da876bfd956"
+dependencies = [
+ "libc",
+ "serde",
+ "serde_json",
+ "winapi",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3232,6 +3392,12 @@ dependencies = [
  "rayon",
  "winapi",
 ]
+
+[[package]]
+name = "target-lexicon"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7fa7e55043acb85fca6b3c01485a2eeb6b69c5d21002e273c79e465f43b7ac1"
 
 [[package]]
 name = "tempfile"

--- a/src/ledger/Cargo.toml
+++ b/src/ledger/Cargo.toml
@@ -16,10 +16,11 @@ hex = "0.4.3"
 lazy_static = "1.4.0"
 minicbor = { version = "0.12.0", features = ["derive", "std"] }
 num-bigint = "0.4.3"
-many = { git = "https://github.com/l-1-labs/many-rs.git", rev = "4b642446c83cc5d541773fdd2c343733c803900b" }
-many-client = { git = "https://github.com/l-1-labs/many-rs.git", rev = "4b642446c83cc5d541773fdd2c343733c803900b" }
+many = { git = "https://github.com/l-1-labs/many-rs.git", rev = "26b4d29209907ad8986905fcfa33535ed1ba4f72" }
+many-client = { git = "https://github.com/l-1-labs/many-rs.git", rev = "26b4d29209907ad8986905fcfa33535ed1ba4f72" }
 regex = "1.5.4"
 ring = "0.17.0-alpha.10"
+rpassword = "6.0"
 tracing = "0.1.29"
 tracing-subscriber = "0.3.3"
 tokio = { version = "1.12.0", features = [ "full" ] }


### PR DESCRIPTION
One can now use `ledger` with an HSM.

This PR also fixes a crash when running
```
ledger --pem id1.pem balance FBT  
```
where FBT was treated as an Identity, not as a Symbol. However, the fix modifies how the command-line is used; the symbols need to be given as
```
ledger --pem id1.pem balance some_id -- FBT  
```

I also took the opportunity to migrate the `eprintln!` calls of this binary to `tracing`.

Finally, I tried using the `clap` validators we talked about, but I don't think it fits the purpose (or I just wasn't able to use it properly). We can validate the parameter, but we can't get access to the validated value afterward. It's a yes/no validation, which would require to run the same code twice, once for validation and once to get the identity.