### PR TITLE
Replace `minicose` with `coset`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -466,16 +466,6 @@ dependencies = [
 [[package]]
 name = "ciborium"
 version = "0.2.0"
-source = "git+https://github.com/hansl/ciborium?rev=230e84cf939cfef9d00958f104cafe72774ffc86#230e84cf939cfef9d00958f104cafe72774ffc86"
-dependencies = [
- "ciborium-io 0.2.0 (git+https://github.com/hansl/ciborium?rev=230e84cf939cfef9d00958f104cafe72774ffc86)",
- "ciborium-ll 0.2.0 (git+https://github.com/hansl/ciborium?rev=230e84cf939cfef9d00958f104cafe72774ffc86)",
- "serde",
-]
-
-[[package]]
-name = "ciborium"
-version = "0.2.0"
 source = "git+https://github.com/enarx/ciborium#2ca375e6b33d1ade5a5798792278b35a807b748e"
 dependencies = [
  "ciborium-io 0.2.0 (git+https://github.com/enarx/ciborium)",
@@ -492,11 +482,6 @@ checksum = "346de753af073cc87b52b2083a506b38ac176a44cfb05497b622e27be899b369"
 [[package]]
 name = "ciborium-io"
 version = "0.2.0"
-source = "git+https://github.com/hansl/ciborium?rev=230e84cf939cfef9d00958f104cafe72774ffc86#230e84cf939cfef9d00958f104cafe72774ffc86"
-
-[[package]]
-name = "ciborium-io"
-version = "0.2.0"
 source = "git+https://github.com/enarx/ciborium#2ca375e6b33d1ade5a5798792278b35a807b748e"
 
 [[package]]
@@ -506,15 +491,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "213030a2b5a4e0c0892b6652260cf6ccac84827b83a85a534e178e3906c4cf1b"
 dependencies = [
  "ciborium-io 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "half",
-]
-
-[[package]]
-name = "ciborium-ll"
-version = "0.2.0"
-source = "git+https://github.com/hansl/ciborium?rev=230e84cf939cfef9d00958f104cafe72774ffc86#230e84cf939cfef9d00958f104cafe72774ffc86"
-dependencies = [
- "ciborium-io 0.2.0 (git+https://github.com/hansl/ciborium?rev=230e84cf939cfef9d00958f104cafe72774ffc86)",
  "half",
 ]
 
@@ -843,12 +819,6 @@ dependencies = [
  "quote",
  "syn",
 ]
-
-[[package]]
-name = "data-encoding"
-version = "2.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ee2393c4a91429dffb4bedf19f4d6abf27d8a732c8ce4980305d782e5426d57"
 
 [[package]]
 name = "debug-helper"
@@ -1786,7 +1756,7 @@ dependencies = [
 [[package]]
 name = "many"
 version = "0.1.0"
-source = "git+https://github.com/l-1-labs/many-rs.git?rev=454d5375f00d56e2718f1a3ba275082901298653#454d5375f00d56e2718f1a3ba275082901298653"
+source = "git+https://github.com/l-1-labs/many-rs.git?rev=6c193b317a5f2f8f5394da59ea7ad88049592fc7#6c193b317a5f2f8f5394da59ea7ad88049592fc7"
 dependencies = [
  "anyhow",
  "asn1",
@@ -1794,6 +1764,7 @@ dependencies = [
  "base32",
  "base64 0.13.0",
  "cbor-diag",
+ "coset",
  "crc-any",
  "cryptoki",
  "derive_builder",
@@ -1805,7 +1776,6 @@ dependencies = [
  "lazy_static",
  "many-macros",
  "minicbor",
- "minicose",
  "num-bigint 0.4.3",
  "num-derive",
  "num-traits",
@@ -1823,7 +1793,7 @@ dependencies = [
  "sha2 0.10.2",
  "sha3",
  "signature",
- "simple_asn1 0.5.4",
+ "simple_asn1",
  "static_assertions",
  "thiserror",
  "tiny_http",
@@ -1859,7 +1829,7 @@ dependencies = [
 [[package]]
 name = "many-client"
 version = "0.1.0"
-source = "git+https://github.com/l-1-labs/many-rs.git?rev=454d5375f00d56e2718f1a3ba275082901298653#454d5375f00d56e2718f1a3ba275082901298653"
+source = "git+https://github.com/l-1-labs/many-rs.git?rev=6c193b317a5f2f8f5394da59ea7ad88049592fc7#6c193b317a5f2f8f5394da59ea7ad88049592fc7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1867,6 +1837,7 @@ dependencies = [
  "base32",
  "base64 0.13.0",
  "cbor-diag",
+ "coset",
  "crc-any",
  "derive_builder",
  "ecdsa",
@@ -1877,7 +1848,6 @@ dependencies = [
  "lazy_static",
  "many",
  "minicbor",
- "minicose",
  "num-bigint 0.4.3",
  "num-derive",
  "num-traits",
@@ -1892,7 +1862,7 @@ dependencies = [
  "serde",
  "sha3",
  "signature",
- "simple_asn1 0.5.4",
+ "simple_asn1",
  "static_assertions",
  "thiserror",
  "tiny_http",
@@ -1932,7 +1902,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha3",
- "simple_asn1 0.5.4",
+ "simple_asn1",
  "tracing",
  "tracing-subscriber 0.2.25",
 ]
@@ -1958,7 +1928,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha3",
- "simple_asn1 0.5.4",
+ "simple_asn1",
  "tempfile",
  "tracing",
  "tracing-subscriber 0.2.25",
@@ -1968,7 +1938,7 @@ dependencies = [
 [[package]]
 name = "many-macros"
 version = "0.1.0"
-source = "git+https://github.com/l-1-labs/many-rs.git?rev=454d5375f00d56e2718f1a3ba275082901298653#454d5375f00d56e2718f1a3ba275082901298653"
+source = "git+https://github.com/l-1-labs/many-rs.git?rev=6c193b317a5f2f8f5394da59ea7ad88049592fc7#6c193b317a5f2f8f5394da59ea7ad88049592fc7"
 dependencies = [
  "inflections",
  "proc-macro2",
@@ -2044,20 +2014,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "minicose"
-version = "0.1.0"
-source = "git+https://github.com/l-1-labs/rust-minicose.git#3b8cd133fe028bc78f26eae30ea87e23f2f9e91b"
-dependencies = [
- "ciborium 0.2.0 (git+https://github.com/hansl/ciborium?rev=230e84cf939cfef9d00958f104cafe72774ffc86)",
- "ciborium-ll 0.2.0 (git+https://github.com/hansl/ciborium?rev=230e84cf939cfef9d00958f104cafe72774ffc86)",
- "data-encoding",
- "derive_builder",
- "serde",
- "serde_bytes",
- "simple_asn1 0.6.1",
 ]
 
 [[package]]
@@ -2623,15 +2579,6 @@ checksum = "2d0a014229361011dc8e69c8a1ec6c2e8d0f2af7c91e3ea3f5b2170298461e68"
 dependencies = [
  "bytes",
  "prost",
-]
-
-[[package]]
-name = "quickcheck"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "588f6378e4dd99458b60ec275b4477add41ce4fa9f64dcba6f15adccb19b50d6"
-dependencies = [
- "rand 0.8.5",
 ]
 
 [[package]]
@@ -3210,18 +3157,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "simple_asn1"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a762b1c38b9b990c694b9c2f8abe3372ce6a9ceaae6bca39cfc46e054f45745"
-dependencies = [
- "num-bigint 0.4.3",
- "num-traits",
- "thiserror",
- "time 0.3.9",
-]
-
-[[package]]
 name = "slab"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3566,10 +3501,8 @@ version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2702e08a7a860f005826c6815dcac101b19b5eb330c27fe4a5928fec1d20ddd"
 dependencies = [
- "itoa",
  "libc",
  "num_threads",
- "quickcheck",
  "time-macros",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -455,6 +455,17 @@ checksum = "fff857943da45f546682664a79488be82e69e43c1a7a2307679ab9afb3a66d2e"
 [[package]]
 name = "ciborium"
 version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c137568cc60b904a7724001b35ce2630fd00d5d84805fbb608ab89509d788f"
+dependencies = [
+ "ciborium-io 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ciborium-ll 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde",
+]
+
+[[package]]
+name = "ciborium"
+version = "0.2.0"
 source = "git+https://github.com/hansl/ciborium?rev=230e84cf939cfef9d00958f104cafe72774ffc86#230e84cf939cfef9d00958f104cafe72774ffc86"
 dependencies = [
  "ciborium-io 0.2.0 (git+https://github.com/hansl/ciborium?rev=230e84cf939cfef9d00958f104cafe72774ffc86)",
@@ -475,12 +486,28 @@ dependencies = [
 [[package]]
 name = "ciborium-io"
 version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346de753af073cc87b52b2083a506b38ac176a44cfb05497b622e27be899b369"
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.0"
 source = "git+https://github.com/hansl/ciborium?rev=230e84cf939cfef9d00958f104cafe72774ffc86#230e84cf939cfef9d00958f104cafe72774ffc86"
 
 [[package]]
 name = "ciborium-io"
 version = "0.2.0"
 source = "git+https://github.com/enarx/ciborium#2ca375e6b33d1ade5a5798792278b35a807b748e"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "213030a2b5a4e0c0892b6652260cf6ccac84827b83a85a534e178e3906c4cf1b"
+dependencies = [
+ "ciborium-io 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "half",
+]
 
 [[package]]
 name = "ciborium-ll"
@@ -618,6 +645,16 @@ name = "core-foundation-sys"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
+
+[[package]]
+name = "coset"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55bc3ff8849ba4144fefd28e719c1c52b63659f835746aceaa7224956a2ccacb"
+dependencies = [
+ "ciborium 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ciborium-io 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "cpufeatures"
@@ -1701,9 +1738,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.122"
+version = "0.2.123"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec647867e2bf0772e28c8bcde4f0d19a9216916e890543b5a03ed8ef27b8f259"
+checksum = "cb691a747a7ab48abc15c5b42066eaafde10dc427e3b6ee2a1cf43db04c763bd"
 
 [[package]]
 name = "libloading"
@@ -1801,12 +1838,12 @@ dependencies = [
  "async-trait",
  "ciborium 0.2.0 (git+https://github.com/enarx/ciborium)",
  "clap 3.1.8",
+ "coset",
  "hex",
  "lazy_static",
  "many",
  "many-client",
  "minicbor",
- "minicose",
  "reqwest",
  "sha2 0.10.2",
  "smol",
@@ -2557,9 +2594,9 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bd5316aa8f5c82add416dfbc25116b84b748a21153f512917e8143640a71bbd"
+checksum = "a07b0857a71a8cb765763950499cae2413c3f9cede1133478c43600d9e146890"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -2567,9 +2604,9 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df35198f0777b75e9ff669737c6da5136b59dba33cf5a010a6d1cc4d56defc6f"
+checksum = "7b670f45da57fb8542ebdbb6105a925fe571b67f9e7ed9f47a06a84e72b4e7cc"
 dependencies = [
  "anyhow",
  "itertools",
@@ -2580,9 +2617,9 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "926681c118ae6e512a3ccefd4abbe5521a14f4cc1e207356d4d00c0b7f2006fd"
+checksum = "2d0a014229361011dc8e69c8a1ec6c2e8d0f2af7c91e3ea3f5b2170298461e68"
 dependencies = [
  "bytes",
  "prost",
@@ -2689,9 +2726,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.5.1"
+version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06aca804d41dbc8ba42dfd964f0d01334eceb64314b9ecf7c5fad5188a06d90"
+checksum = "fd249e82c21598a9a426a4e00dd7adc1d640b22445ec8545feef801d1a74c221"
 dependencies = [
  "autocfg",
  "crossbeam-deque",
@@ -2701,14 +2738,13 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.9.1"
+version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d78120e2c850279833f1dd3582f730c4ab53ed95aeaaaa862a2a5c71b1656d8e"
+checksum = "9f51245e1e62e1f1629cbfec37b5793bbabcaeb90f30e94d2ba03564687353e4"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-deque",
  "crossbeam-utils",
- "lazy_static",
  "num_cpus",
 ]
 
@@ -3324,9 +3360,9 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.23.9"
+version = "0.23.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3fb8adaa82317f1e8a040281807f411803c9111303cfe129b4abb4a14b2c223"
+checksum = "4eea2ed6847da2e0c7289f72cb4f285f0bd704694ca067d32be811b2a45ea858"
 dependencies = [
  "cfg-if",
  "core-foundation-sys",
@@ -3360,7 +3396,7 @@ dependencies = [
 [[package]]
 name = "tendermint"
 version = "0.24.0-pre.1"
-source = "git+https://github.com/informalsystems/tendermint-rs.git#b23d626c9ca45dec8f5ca3e31bb493d810bafc5d"
+source = "git+https://github.com/informalsystems/tendermint-rs.git#7a8d681027b92a27174a3fd5c6e893dc35f42c31"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3388,7 +3424,7 @@ dependencies = [
 [[package]]
 name = "tendermint-abci"
 version = "0.24.0-pre.1"
-source = "git+https://github.com/informalsystems/tendermint-rs.git#b23d626c9ca45dec8f5ca3e31bb493d810bafc5d"
+source = "git+https://github.com/informalsystems/tendermint-rs.git#7a8d681027b92a27174a3fd5c6e893dc35f42c31"
 dependencies = [
  "bytes",
  "flex-error",
@@ -3400,7 +3436,7 @@ dependencies = [
 [[package]]
 name = "tendermint-config"
 version = "0.24.0-pre.1"
-source = "git+https://github.com/informalsystems/tendermint-rs.git#b23d626c9ca45dec8f5ca3e31bb493d810bafc5d"
+source = "git+https://github.com/informalsystems/tendermint-rs.git#7a8d681027b92a27174a3fd5c6e893dc35f42c31"
 dependencies = [
  "flex-error",
  "serde",
@@ -3413,7 +3449,7 @@ dependencies = [
 [[package]]
 name = "tendermint-proto"
 version = "0.24.0-pre.1"
-source = "git+https://github.com/informalsystems/tendermint-rs.git#b23d626c9ca45dec8f5ca3e31bb493d810bafc5d"
+source = "git+https://github.com/informalsystems/tendermint-rs.git#7a8d681027b92a27174a3fd5c6e893dc35f42c31"
 dependencies = [
  "bytes",
  "flex-error",
@@ -3430,7 +3466,7 @@ dependencies = [
 [[package]]
 name = "tendermint-rpc"
 version = "0.24.0-pre.1"
-source = "git+https://github.com/informalsystems/tendermint-rs.git#b23d626c9ca45dec8f5ca3e31bb493d810bafc5d"
+source = "git+https://github.com/informalsystems/tendermint-rs.git#7a8d681027b92a27174a3fd5c6e893dc35f42c31"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3677,9 +3713,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.24"
+version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90442985ee2f57c9e1b548ee72ae842f4a9a20e3f417cc38dbc5dc684d9bb4ee"
+checksum = "6dfce9f3241b150f36e8e54bb561a742d5daa1a47b5dd9a5ce369fd4a4db2210"
 dependencies = [
  "lazy_static",
  "valuable",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,12 +10,8 @@ members = [
     "src/many-ledger",
 ]
 
-# Uncomment this for local builds of minicose.
-#[patch."https://github.com/l-1-labs/rust-minicose"]
-#minicose = { path = "../rust-minicose" }
-
-#[patch."https://github.com/l-1-labs/many-rs.git"]
-#many = { path = "../many-rs/src/many" }
-#many-cli = { path = "../many-rs/src/many-cli" }
-#many-client = { path = "../many-rs/src/many-client" }
-#many-macros = { path = "../many-rs/src/many-macros" }
+# [patch."https://github.com/l-1-labs/many-rs.git"]
+# many = { path = "../many-rs/src/many" }
+# many-cli = { path = "../many-rs/src/many-cli" }
+# many-client = { path = "../many-rs/src/many-client" }
+# many-macros = { path = "../many-rs/src/many-macros" }

--- a/src/http_proxy/Cargo.toml
+++ b/src/http_proxy/Cargo.toml
@@ -11,8 +11,8 @@ doc = false
 clap = { version = "3.0.0", features = ["derive"] }
 hex = "0.4.3"
 minicbor = { version = "0.12.0", features = ["derive", "std"] }
-many = { git = "https://github.com/l-1-labs/many-rs.git", rev = "454d5375f00d56e2718f1a3ba275082901298653" }
-many-client = { git = "https://github.com/l-1-labs/many-rs.git", rev = "454d5375f00d56e2718f1a3ba275082901298653" }
+many = { git = "https://github.com/l-1-labs/many-rs.git", rev = "6c193b317a5f2f8f5394da59ea7ad88049592fc7" }
+many-client = { git = "https://github.com/l-1-labs/many-rs.git", rev = "6c193b317a5f2f8f5394da59ea7ad88049592fc7" }
 many-kvstore = { path = "../many-kvstore" }
 new_mime_guess = "4.0.0"
 tiny_http = "0.9.0"

--- a/src/kvstore/Cargo.toml
+++ b/src/kvstore/Cargo.toml
@@ -11,8 +11,8 @@ doc = false
 clap = { version = "3.0.0", features = ["derive"] }
 hex = "0.4.3"
 minicbor = { version = "0.12.0", features = ["derive", "std"] }
-many = { git = "https://github.com/l-1-labs/many-rs.git", rev = "454d5375f00d56e2718f1a3ba275082901298653" }
-many-client = { git = "https://github.com/l-1-labs/many-rs.git", rev = "454d5375f00d56e2718f1a3ba275082901298653" }
+many = { git = "https://github.com/l-1-labs/many-rs.git", rev = "6c193b317a5f2f8f5394da59ea7ad88049592fc7" }
+many-client = { git = "https://github.com/l-1-labs/many-rs.git", rev = "6c193b317a5f2f8f5394da59ea7ad88049592fc7" }
 many-kvstore = { path = "../many-kvstore" }
 tracing = "0.1.29"
 tracing-subscriber = "0.3.3"

--- a/src/ledger/Cargo.toml
+++ b/src/ledger/Cargo.toml
@@ -16,8 +16,8 @@ hex = "0.4.3"
 lazy_static = "1.4.0"
 minicbor = { version = "0.12.0", features = ["derive", "std"] }
 num-bigint = "0.4.3"
-many = { git = "https://github.com/l-1-labs/many-rs.git", rev = "454d5375f00d56e2718f1a3ba275082901298653" }
-many-client = { git = "https://github.com/l-1-labs/many-rs.git", rev = "454d5375f00d56e2718f1a3ba275082901298653" }
+many = { git = "https://github.com/l-1-labs/many-rs.git", rev = "6c193b317a5f2f8f5394da59ea7ad88049592fc7" }
+many-client = { git = "https://github.com/l-1-labs/many-rs.git", rev = "6c193b317a5f2f8f5394da59ea7ad88049592fc7" }
 regex = "1.5.4"
 ring = "0.17.0-alpha.10"
 rpassword = "6.0"

--- a/src/many-abci/Cargo.toml
+++ b/src/many-abci/Cargo.toml
@@ -11,10 +11,10 @@ doc = false
 async-trait = "0.1.51"
 ciborium = { git = "https://github.com/enarx/ciborium" }
 clap = { version = "3.0.0", features = ["derive"] }
+coset = "0.3"
 hex = "0.4.3"
 lazy_static = "1.4.0"
 minicbor = { version = "0.12.0", features = ["derive", "std"] }
-minicose = { git = "https://github.com/l-1-labs/rust-minicose.git" }
 many = { git = "https://github.com/l-1-labs/many-rs.git", rev = "454d5375f00d56e2718f1a3ba275082901298653" }
 many-client = { git = "https://github.com/l-1-labs/many-rs.git", rev = "454d5375f00d56e2718f1a3ba275082901298653" }
 reqwest = "0.11.6"

--- a/src/many-abci/Cargo.toml
+++ b/src/many-abci/Cargo.toml
@@ -15,8 +15,8 @@ coset = "0.3"
 hex = "0.4.3"
 lazy_static = "1.4.0"
 minicbor = { version = "0.12.0", features = ["derive", "std"] }
-many = { git = "https://github.com/l-1-labs/many-rs.git", rev = "454d5375f00d56e2718f1a3ba275082901298653" }
-many-client = { git = "https://github.com/l-1-labs/many-rs.git", rev = "454d5375f00d56e2718f1a3ba275082901298653" }
+many = { git = "https://github.com/l-1-labs/many-rs.git", rev = "6c193b317a5f2f8f5394da59ea7ad88049592fc7" }
+many-client = { git = "https://github.com/l-1-labs/many-rs.git", rev = "6c193b317a5f2f8f5394da59ea7ad88049592fc7" }
 reqwest = "0.11.6"
 sha2 = "0.10.1"
 smol = "1.2.5"

--- a/src/many-abci/src/abci_app.rs
+++ b/src/many-abci/src/abci_app.rs
@@ -1,9 +1,9 @@
+use coset::{CborSerializable, CoseSign1};
 use many::message::ResponseMessage;
 use many::server::module::abci_backend::{AbciBlock, AbciCommitInfo, AbciInfo};
 use many::types::identity::cose::CoseKeyIdentity;
 use many::{Identity, ManyError};
 use many_client::ManyClient;
-use minicose::CoseSign1;
 use reqwest::{IntoUrl, Url};
 use std::time::SystemTime;
 use tendermint_abci::Application;
@@ -79,7 +79,7 @@ impl Application for AbciApp {
         Default::default()
     }
     fn query(&self, request: RequestQuery) -> ResponseQuery {
-        let cose = match CoseSign1::from_bytes(&request.data) {
+        let cose = match CoseSign1::from_slice(&request.data) {
             Ok(x) => x,
             Err(err) => {
                 return ResponseQuery {
@@ -100,7 +100,8 @@ impl Application for AbciApp {
                 }
             }
         };
-        match value.to_bytes() {
+
+        match value.to_vec() {
             Ok(value) => ResponseQuery {
                 code: 0,
                 value: value.into(),
@@ -126,7 +127,7 @@ impl Application for AbciApp {
     }
 
     fn deliver_tx(&self, request: RequestDeliverTx) -> ResponseDeliverTx {
-        let cose = match CoseSign1::from_bytes(&request.tx) {
+        let cose = match CoseSign1::from_slice(&request.tx) {
             Ok(x) => x,
             Err(err) => {
                 return ResponseDeliverTx {

--- a/src/many-abci/src/module.rs
+++ b/src/many-abci/src/module.rs
@@ -1,3 +1,4 @@
+use coset::{CborSerializable, CoseSign1};
 use many::server::module::r#async::{StatusArgs, StatusReturn};
 use many::server::module::{abci_frontend, blockchain, r#async};
 use many::types::blockchain::{
@@ -6,7 +7,6 @@ use many::types::blockchain::{
 };
 use many::types::Timestamp;
 use many::{Identity, ManyError};
-use minicose::CoseSign1;
 use tendermint::Time;
 use tendermint_rpc::Client;
 
@@ -74,8 +74,10 @@ impl<C: Client + Send + Sync> r#async::AsyncModuleBackend for AbciBlockchainModu
                     .await
                 {
                     Ok(tx) => Ok(StatusReturn::Done {
-                        response: CoseSign1::from_bytes(tx.tx.as_bytes())
-                            .map_err(|e| abci_frontend::abci_transport_error(e.to_string()))?,
+                        response: Box::new(
+                            CoseSign1::from_slice(tx.tx.as_bytes())
+                                .map_err(|e| abci_frontend::abci_transport_error(e.to_string()))?,
+                        ),
                     }),
 
                     Err(_) => Ok(StatusReturn::Unknown),

--- a/src/many-hwinfo/Cargo.toml
+++ b/src/many-hwinfo/Cargo.toml
@@ -12,7 +12,7 @@ async-trait = "0.1.51"
 clap = { version = "3.0.0", features = ["derive"] }
 hex = "0.4.3"
 minicbor = { version = "0.12.0", features = ["derive", "std"] }
-many = { git = "https://github.com/l-1-labs/many-rs.git", rev = "454d5375f00d56e2718f1a3ba275082901298653", features = ["pem"] }
+many = { git = "https://github.com/l-1-labs/many-rs.git", rev = "6c193b317a5f2f8f5394da59ea7ad88049592fc7", features = ["pem"] }
 sysinfo = "0.23.1"
 sys-info = "0.9.1"
 tracing = "0.1.28"

--- a/src/many-kvstore/Cargo.toml
+++ b/src/many-kvstore/Cargo.toml
@@ -16,7 +16,7 @@ itertools = "0.10.3"
 lazy_static = "1.4.0"
 num-bigint = "0.4.3"
 minicbor = { version = "0.12.0", features = ["derive", "std"] }
-many = { git = "https://github.com/l-1-labs/many-rs.git", rev = "454d5375f00d56e2718f1a3ba275082901298653", features = ["pem"] }
+many = { git = "https://github.com/l-1-labs/many-rs.git", rev = "6c193b317a5f2f8f5394da59ea7ad88049592fc7", features = ["pem"] }
 many-abci = { path = "../many-abci" }
 serde = "1.0.130"
 serde_json = "1.0.72"

--- a/src/many-ledger/Cargo.toml
+++ b/src/many-ledger/Cargo.toml
@@ -18,7 +18,7 @@ lazy_static = "1.4.0"
 num-bigint = "0.4.3"
 num-traits = "0.2.14"
 minicbor = { version = "0.12.0", features = ["derive", "std"] }
-many = { git = "https://github.com/l-1-labs/many-rs.git", rev = "454d5375f00d56e2718f1a3ba275082901298653", features = ["pem", "raw"] }
+many = { git = "https://github.com/l-1-labs/many-rs.git", rev = "6c193b317a5f2f8f5394da59ea7ad88049592fc7", features = ["pem", "raw"] }
 many-abci = { path = "../many-abci" }
 many-kvstore = { path = "../many-kvstore" }
 serde = "1.0.130"
@@ -30,7 +30,7 @@ tracing-subscriber = "0.2.24"
 typenum = "1.15.0"
 
 [dev-dependencies]
-many = { git = "https://github.com/l-1-labs/many-rs.git", rev = "454d5375f00d56e2718f1a3ba275082901298653" }
-many-client = { git = "https://github.com/l-1-labs/many-rs.git", rev = "454d5375f00d56e2718f1a3ba275082901298653" }
+many = { git = "https://github.com/l-1-labs/many-rs.git", rev = "6c193b317a5f2f8f5394da59ea7ad88049592fc7" }
+many-client = { git = "https://github.com/l-1-labs/many-rs.git", rev = "6c193b317a5f2f8f5394da59ea7ad88049592fc7" }
 tempfile = "3.3.0"
 


### PR DESCRIPTION
This is a first iteration where minicose was nuked and replaced with
coset. The code is in a working state.

Dependant on https://github.com/l-1-labs/many-rs/pull/47

Fixes #58