### PR TITLE
Enable CI on PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,10 @@
-on: [push]
-
 name: CI
-
+on:
+  - push
+  - pull_request
 jobs:
   build_and_test:
-    name: many-ledger build and tests
+    name: many-framework build and tests
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
CI will run when a PR is opened, synchronized or reopened.

When a first-time contributor submits a pull request to a public
repository, a maintainer with write access may need to approve running
workflows on the pull request.

Fixes #62 